### PR TITLE
BUGFIX: modern setuptools no longer accepts unordered sets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ except ImportError:
     from distutils.core import setup, find_packages
 
 sys.dont_write_bytecode = True
-py2_requirements = set(pkutils.parse_requirements('py2-requirements.txt'))
-dev_requirements = set(pkutils.parse_requirements('dev-requirements.txt'))
+py2_requirements = list(set(pkutils.parse_requirements('py2-requirements.txt')))
+dev_requirements = list(set(pkutils.parse_requirements('dev-requirements.txt')))
 readme = pkutils.read('README.rst')
 changes = pkutils.read(p.join('docs', 'CHANGES.rst'))
 module = pkutils.parse_module(p.join('pygogo', '__init__.py'))


### PR DESCRIPTION
Since closing [https://github.com/pypa/setuptools/issues/458](https://github.com/pypa/setuptools/issues/458), setuptools no longer accepts unordered sets for a dependency list, which makes any setup.py call fail with the following error, breaking the installation:

`  error in pygogo setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Unordered types are not allowed`

Since we don't care about the order at this point, let's just force it to be a list.